### PR TITLE
fix field name typo: architect -> architects

### DIFF
--- a/templates/includes/skyscraper-page-table.php
+++ b/templates/includes/skyscraper-page-table.php
@@ -5,7 +5,7 @@ $url = config('urls')->root . "search/";
 $height = $page->get('height');
 $floors = $page->get('floors');
 $year = $page->get('year');
-$architects = $page->get('architect');
+$architects = $page->get('architects');
 
 ?>
 <table class='uk-table skyscraper-info'>


### PR DESCRIPTION
someone in the forums got an error here and i think this might fix it

https://processwire.com/talk/topic/27944-problems-with-skyscraper-profile/